### PR TITLE
Problem with big files fixed

### DIFF
--- a/src/main/groovy/eu/emundo/gradle/sevenz/UnSevenZ.groovy
+++ b/src/main/groovy/eu/emundo/gradle/sevenz/UnSevenZ.groovy
@@ -33,17 +33,11 @@ class UnSevenZ extends DefaultTask {
                 parent.mkdirs()
             }
 
-            final BufferedOutputStream out = new BufferedOutputStream(new FileOutputStream(curfile));
             int currByte = 0;
-
-            try {
+            new BufferedOutputStream(new FileOutputStream(curfile)).withStream { ostream ->
                 while( (currByte = sevenZFile.read()) != -1 ) {
-                    out.write(currByte);
+                    ostream.write(currByte);
                 }
-            } catch(IOException e) {
-                e.printStackTrace();
-            } finally {
-                out.close();
             }
         }
     }

--- a/src/main/groovy/eu/emundo/gradle/sevenz/UnSevenZ.groovy
+++ b/src/main/groovy/eu/emundo/gradle/sevenz/UnSevenZ.groovy
@@ -32,11 +32,19 @@ class UnSevenZ extends DefaultTask {
             if (parent != null && !parent.exists()) {
                 parent.mkdirs()
             }
-            FileOutputStream out = new FileOutputStream(curfile)
-            byte[] content = new byte[(int) entry.getSize()]
-            sevenZFile.read(content, 0, content.length)
-            out.write(content)
-            out.close()
+
+            final BufferedOutputStream out = new BufferedOutputStream(new FileOutputStream(curfile));
+            int currByte = 0;
+
+            try {
+                while( (currByte = sevenZFile.read()) != -1 ) {
+                    out.write(currByte);
+                }
+            } catch(IOException e) {
+                e.printStackTrace();
+            } finally {
+                out.close();
+            }
         }
     }
 


### PR DESCRIPTION
Big files caused an Array-Overflow on big files at: new byte[...],
because entry.getSize() can return a long value.