### PR TITLE
Add statement to close sevenZFile object 

### DIFF
--- a/src/main/groovy/eu/emundo/gradle/sevenz/UnSevenZ.groovy
+++ b/src/main/groovy/eu/emundo/gradle/sevenz/UnSevenZ.groovy
@@ -23,24 +23,25 @@ class UnSevenZ extends DefaultTask {
     void extract(IncrementalTaskInputs inputs) {
         SevenZFile sevenZFile = new SevenZFile(sourceFile)
         SevenZArchiveEntry entry
-        while ((entry = sevenZFile.getNextEntry()) != null) {
-            if (entry.isDirectory()) {
-                continue
-            }
-            File curfile = new File(outputDir, entry.getName())
-            File parent = curfile.getParentFile()
-            if (parent != null && !parent.exists()) {
-                parent.mkdirs()
-            }
+        sevenZFile.withCloseable {
+            while ((entry = sevenZFile.getNextEntry()) != null) {
+                if (entry.isDirectory()) {
+                    continue
+                }
+                File curfile = new File(outputDir, entry.getName())
+                File parent = curfile.getParentFile()
+                if (parent != null && !parent.exists()) {
+                    parent.mkdirs()
+                }
 
-            int currByte = 0;
-            new BufferedOutputStream(new FileOutputStream(curfile)).withStream { ostream ->
-                while( (currByte = sevenZFile.read()) != -1 ) {
-                    ostream.write(currByte);
+                int currByte = 0;
+                new BufferedOutputStream(new FileOutputStream(curfile)).withStream { ostream ->
+                    while ((currByte = sevenZFile.read()) != -1) {
+                        ostream.write(currByte);
+                    }
                 }
             }
         }
-        sevenZFile.close()
     }
 
 }

--- a/src/main/groovy/eu/emundo/gradle/sevenz/UnSevenZ.groovy
+++ b/src/main/groovy/eu/emundo/gradle/sevenz/UnSevenZ.groovy
@@ -40,6 +40,7 @@ class UnSevenZ extends DefaultTask {
                 }
             }
         }
+        sevenZFile.close()
     }
 
 }


### PR DESCRIPTION
#4 I just added a line to close the SevenZFile object. A simple call to the `close()` method of the class.
I've tested it on a local project and it works like a charm!

Hope it fits!